### PR TITLE
Add a javascript example for the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,33 @@
-# Description 
+# Description
+
 This repository contains examples of using the AISStream API in Golang, Python, JavaScript and many more languages.
 
 ## Prerequisites
+
 Before you can use these examples, you will need to sign up for an AISStream API key at [aisstream.io](https://aisstream.io/authenticate).
 
 ### Golang Example
+
 To run the Golang example, you will need to have Go installed on your system.
 
 Clone the repository: `git clone https://github.com/aisstream/example`. Navigate to the golang directory: `cd example/golang`. Install the dependencies: `go get -d`. Replace "<YOUR API KEY>" in the main.go file with your AISStream API key. Run the example: `go run main.go`.
-  
- 
+
 ### Python Example
+
 To run the Python example, you will need to have Python 3 installed on your system.
 
 Clone the repository: `git clone https://github.com/aisstream/example`. Navigate to the python directory: `cd example/python`. Install the dependencies: `python setup.py install`. Replace "<YOUR API KEY>" in the main.py file with your AISStream API key. Run the example: python main.py.
-  
+
 ### JavaScript Example
+
 To run the JavaScript example, you will need to have Node.js installed on your system.
 
 Clone the repository: `git clone https://github.com/aisstream/example`. Navigate to the javascript directory: `cd example/javascript`. Install the dependencies: `npm install`. Replace "<YOUR API KEY>" in the index.js file with your AISStream API key.. Run the example: `node index.js`.
 
+### JavaScript Browser Example
+
+Clone the repository: `git clone https://github.com/aisstream/example`. Navigate to the javascript-browser directory: `cd example/javascript-browser`. Run a basic HTTP server, such as: `python -m SimpleHTTPServer`. Replace "<YOUR API KEY>" in the index.js file with your AISStream API key. Open the page `localhost:8000` in your browser.
+
 ### Additional Resources
-  
+
 For more information on the AISStream API, visit the [AISStream documentation](https://aisstream.io/documentation).

--- a/javascript-browser/index.html
+++ b/javascript-browser/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <div id="position-data">
+    </div>
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/javascript-browser/index.js
+++ b/javascript-browser/index.js
@@ -1,0 +1,35 @@
+const container = document.getElementById("position-data");
+
+const socket = new WebSocket("wss://stream.aisstream.io/v0/stream");
+
+socket.onopen = function (event) {
+  console.log("socket is open", event);
+  const subscriptionMessage = {
+    Apikey: "<YOUR API KEY>",
+    BoundingBoxes: [
+      [
+        [-180, -90],
+        [180, 90],
+      ],
+    ],
+  };
+  socket.send(JSON.stringify(subscriptionMessage));
+};
+
+socket.onmessage = function (event) {
+  const aisMessage = JSON.parse(event.data);
+  if (aisMessage["MessageType"] === "PositionReport") {
+    let positionReport = aisMessage["Message"]["PositionReport"];
+    const positionMessage = `ShipId: ${positionReport["UserID"]} Latitude: ${positionReport["Latitude"]} Latitude: ${positionReport["Longitude"]}`;
+    console.log(positionMessage);
+    const span = document.createElement("span");
+    span.innerText = positionMessage;
+    container.appendChild(span);
+  }
+};
+
+socket.onclose = function (event) {
+  console.log("socket is closed", event);
+};
+
+console.log("created socket", socket);


### PR DESCRIPTION
The current example is for nodejs, but I think it would be helpful to have one for the browser.

This example does not currently work as written. See https://github.com/aisstream/issues/issues/6#issuecomment-1418511882